### PR TITLE
perf: register drag listeners on document only during drag

### DIFF
--- a/src/components/SplitterLayout.tsx
+++ b/src/components/SplitterLayout.tsx
@@ -183,6 +183,17 @@ function SplitterLayout({
     processMoveAt(e.changedTouches[0].clientX, e.changedTouches[0].clientY);
   }, [processMoveAt]);
 
+  const removeDragListeners = useCallback(() => {
+    const listeners = registeredListenersRef.current;
+    if (listeners) {
+      document.removeEventListener('mouseup', listeners.mouseUp);
+      document.removeEventListener('mousemove', listeners.mouseMove);
+      document.removeEventListener('touchend', listeners.touchEnd);
+      document.removeEventListener('touchmove', listeners.touchMove);
+      registeredListenersRef.current = null;
+    }
+  }, []);
+
   const handleMouseUp = useCallback(() => {
     if (rafIdRef.current !== null) {
       cancelAnimationFrame(rafIdRef.current);
@@ -195,15 +206,8 @@ function SplitterLayout({
       setResizing(false);
       onDragEndRef.current?.();
     }
-    const listeners = registeredListenersRef.current;
-    if (listeners) {
-      document.removeEventListener('mouseup', listeners.mouseUp);
-      document.removeEventListener('mousemove', listeners.mouseMove);
-      document.removeEventListener('touchend', listeners.touchEnd);
-      document.removeEventListener('touchmove', listeners.touchMove);
-      registeredListenersRef.current = null;
-    }
-  }, []);
+    removeDragListeners();
+  }, [removeDragListeners]);
 
   const handleSplitterMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
@@ -247,13 +251,7 @@ function SplitterLayout({
     return () => {
       window.removeEventListener('resize', handleResize);
       // Defensive cleanup: remove drag listeners if component unmounts mid-drag
-      const listeners = registeredListenersRef.current;
-      if (listeners) {
-        document.removeEventListener('mouseup', listeners.mouseUp);
-        document.removeEventListener('mousemove', listeners.mouseMove);
-        document.removeEventListener('touchend', listeners.touchEnd);
-        document.removeEventListener('touchmove', listeners.touchMove);
-      }
+      removeDragListeners();
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;

--- a/src/components/SplitterLayout.tsx
+++ b/src/components/SplitterLayout.tsx
@@ -92,7 +92,12 @@ function SplitterLayout({
   const latestMoveRef = useRef<{ clientX: number; clientY: number } | null>(null);
   const rafIdRef = useRef<number | null>(null);
   const resizingRef = useRef(false);
-  const handleMouseUpRef = useRef<(() => void) | null>(null);
+  const registeredListenersRef = useRef<{
+    mouseUp: () => void;
+    mouseMove: (e: MouseEvent) => void;
+    touchEnd: () => void;
+    touchMove: (e: TouchEvent) => void;
+  } | null>(null);
 
   // Keep latest prop values in refs so event handlers remain stable
   const verticalRef = useRef(vertical);
@@ -190,19 +195,27 @@ function SplitterLayout({
       setResizing(false);
       onDragEndRef.current?.();
     }
-    document.removeEventListener('mouseup', handleMouseUpRef.current!);
-    document.removeEventListener('mousemove', handleMouseMove);
-    document.removeEventListener('touchend', handleMouseUpRef.current!);
-    document.removeEventListener('touchmove', handleTouchMove);
-  }, [handleMouseMove, handleTouchMove]);
-
-  handleMouseUpRef.current = handleMouseUp;
+    const listeners = registeredListenersRef.current;
+    if (listeners) {
+      document.removeEventListener('mouseup', listeners.mouseUp);
+      document.removeEventListener('mousemove', listeners.mouseMove);
+      document.removeEventListener('touchend', listeners.touchEnd);
+      document.removeEventListener('touchmove', listeners.touchMove);
+      registeredListenersRef.current = null;
+    }
+  }, []);
 
   const handleSplitterMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     resizingRef.current = true;
     setResizing(true);
     onDragStartRef.current?.();
+    registeredListenersRef.current = {
+      mouseUp: handleMouseUp,
+      mouseMove: handleMouseMove,
+      touchEnd: handleMouseUp,
+      touchMove: handleTouchMove
+    };
     document.addEventListener('mouseup', handleMouseUp);
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('touchend', handleMouseUp);
@@ -234,12 +247,13 @@ function SplitterLayout({
     return () => {
       window.removeEventListener('resize', handleResize);
       // Defensive cleanup: remove drag listeners if component unmounts mid-drag
-      if (handleMouseUpRef.current) {
-        document.removeEventListener('mouseup', handleMouseUpRef.current);
-        document.removeEventListener('touchend', handleMouseUpRef.current);
+      const listeners = registeredListenersRef.current;
+      if (listeners) {
+        document.removeEventListener('mouseup', listeners.mouseUp);
+        document.removeEventListener('mousemove', listeners.mouseMove);
+        document.removeEventListener('touchend', listeners.touchEnd);
+        document.removeEventListener('touchmove', listeners.touchMove);
       }
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('touchmove', handleTouchMove);
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;

--- a/src/components/SplitterLayout.tsx
+++ b/src/components/SplitterLayout.tsx
@@ -92,6 +92,7 @@ function SplitterLayout({
   const latestMoveRef = useRef<{ clientX: number; clientY: number } | null>(null);
   const rafIdRef = useRef<number | null>(null);
   const resizingRef = useRef(false);
+  const handleMouseUpRef = useRef<(() => void) | null>(null);
 
   // Keep latest prop values in refs so event handlers remain stable
   const verticalRef = useRef(vertical);
@@ -189,21 +190,27 @@ function SplitterLayout({
       setResizing(false);
       onDragEndRef.current?.();
     }
-  }, []);
+    document.removeEventListener('mouseup', handleMouseUpRef.current!);
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('touchend', handleMouseUpRef.current!);
+    document.removeEventListener('touchmove', handleTouchMove);
+  }, [handleMouseMove, handleTouchMove]);
+
+  handleMouseUpRef.current = handleMouseUp;
 
   const handleSplitterMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     resizingRef.current = true;
     setResizing(true);
     onDragStartRef.current?.();
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
     document.addEventListener('mouseup', handleMouseUp);
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('touchend', handleMouseUp);
     document.addEventListener('touchmove', handleTouchMove);
+  }, [handleMouseUp, handleMouseMove, handleTouchMove]);
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
 
     let initialSize: number;
     if (secondaryInitialSize !== undefined) {
@@ -226,9 +233,12 @@ function SplitterLayout({
 
     return () => {
       window.removeEventListener('resize', handleResize);
-      document.removeEventListener('mouseup', handleMouseUp);
+      // Defensive cleanup: remove drag listeners if component unmounts mid-drag
+      if (handleMouseUpRef.current) {
+        document.removeEventListener('mouseup', handleMouseUpRef.current);
+        document.removeEventListener('touchend', handleMouseUpRef.current);
+      }
       document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('touchend', handleMouseUp);
       document.removeEventListener('touchmove', handleTouchMove);
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);

--- a/test/SplitterLayout.spec.tsx
+++ b/test/SplitterLayout.spec.tsx
@@ -212,6 +212,28 @@ describe('SplitterLayout', () => {
       removeSpy.mockRestore();
     });
 
+    it('should remove drag listeners when unmounted during drag', () => {
+      const { container, unmount } = render(
+        <SplitterLayout>
+          <div>Child #0</div>
+          <div>Child #1</div>
+        </SplitterLayout>
+      );
+
+      const splitter = container.querySelector('.layout-splitter') as HTMLElement;
+      fireEvent.mouseDown(splitter);
+
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+      unmount();
+
+      expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
+
+      removeSpy.mockRestore();
+    });
+
     it('should set splitter reference when it is rendered', () => {
       const { container } = render(
         <SplitterLayout>

--- a/test/SplitterLayout.spec.tsx
+++ b/test/SplitterLayout.spec.tsx
@@ -155,10 +155,10 @@ describe('SplitterLayout', () => {
       );
 
       expect(windowSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
+      expect(documentSpy).not.toHaveBeenCalledWith('mouseup', expect.any(Function));
+      expect(documentSpy).not.toHaveBeenCalledWith('mousemove', expect.any(Function));
+      expect(documentSpy).not.toHaveBeenCalledWith('touchend', expect.any(Function));
+      expect(documentSpy).not.toHaveBeenCalledWith('touchmove', expect.any(Function));
 
       windowSpy.mockRestore();
       documentSpy.mockRestore();
@@ -173,18 +173,43 @@ describe('SplitterLayout', () => {
       );
 
       const windowSpy = vi.spyOn(window, 'removeEventListener');
-      const documentSpy = vi.spyOn(document, 'removeEventListener');
 
       unmount();
 
       expect(windowSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
-      expect(documentSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
 
       windowSpy.mockRestore();
-      documentSpy.mockRestore();
+    });
+
+    it('should register and unregister drag listeners on document when drag starts and ends', () => {
+      const { container } = render(
+        <SplitterLayout>
+          <div>Child #0</div>
+          <div>Child #1</div>
+        </SplitterLayout>
+      );
+
+      const splitter = container.querySelector('.layout-splitter') as HTMLElement;
+
+      const addSpy = vi.spyOn(document, 'addEventListener');
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+      fireEvent.mouseDown(splitter);
+
+      expect(addSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+      expect(addSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+      expect(addSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
+      expect(addSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
+
+      fireEvent.mouseUp(document);
+
+      expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
+
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
     });
 
     it('should set splitter reference when it is rendered', () => {

--- a/test/SplitterLayout.spec.tsx
+++ b/test/SplitterLayout.spec.tsx
@@ -173,12 +173,15 @@ describe('SplitterLayout', () => {
       );
 
       const windowSpy = vi.spyOn(window, 'removeEventListener');
+      const documentSpy = vi.spyOn(document, 'removeEventListener');
 
       unmount();
 
       expect(windowSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      expect(documentSpy).not.toHaveBeenCalled();
 
       windowSpy.mockRestore();
+      documentSpy.mockRestore();
     });
 
     it('should register and unregister drag listeners on document when drag starts and ends', () => {


### PR DESCRIPTION
## Summary

- Register `mousemove`/`mouseup`/`touchmove`/`touchend` on `document` only when dragging starts, instead of at mount time
- Remove these listeners when dragging ends
- Defensively remove drag listeners on unmount to handle mid-drag component removal

Closes #9

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (35 tests)
- [x] Verified that drag listeners are not registered on `document` at mount time
- [x] Verified that drag listeners are dynamically added on drag start and removed on drag end

🤖 Generated with [Claude Code](https://claude.com/claude-code)